### PR TITLE
Use AJAX when hiding giveaways

### DIFF
--- a/Extended_Steamgifts.user.js
+++ b/Extended_Steamgifts.user.js
@@ -757,6 +757,25 @@ $(document).on('click', '.trigger-popup', function () {
 $(document).on('click', '.giveaway__hide', function () {
 	$(".popup--hide-games input[name=game_id]").val($(this).attr("data-game-id")),
 	$(".popup--hide-games .popup__heading__bold").text($(this).closest("h2").find(".giveaway__heading__name").text())
+	
+	//Use AJAX when hiding GAs
+	var t = $(".popup--hide-games .form__submit-button.js__submit-form");
+	t.removeClass("is-disabled").html('<i class="fa fa-check-circle"></i> Yes').unbind(); // Reset button state if we had previously hidden GAs
+	t.on("click", function () {
+		var game_id = t.closest("form").find("input[name=game_id]").val();
+		$.ajax({
+			url : "/", // Is unknown if there is an API param for hiding GAs so we post to main page instead
+			type : "POST",
+			dataType : "json",
+			data : t.closest("form").serialize(),
+			complete : function (data) {
+				if(data.readyState === 4) {
+					t.addClass("is-disabled").html("Done!").unbind(); // Don't allow form resubmission if user clicks the button again
+					$(document).find("i[data-game-id=" + game_id + "]").closest(".giveaway__row-outer-wrap").remove(); // Remove all matching visible GAs instances
+				}
+			}
+		});
+	});
 });
 $(document).on('click', 'nav .nav__button--is-dropdown-arrow', function () {
 	var e = $(this).hasClass("is-selected");


### PR DESCRIPTION
Please notice that this is a rather dirty solution. First the AJAX request is not done through ajax.php since I'm not aware of a parameter that would allow hiding of GAs.
Also, after a specific game is hidden all visible instances are removed from page, however ideally (if endless scroll is NOT enabled) you'd want to make the POST to the page you are currently on (/giveaways/search?page=x), extract the GAs from the result and update the page accordingly.
Is not that bad if you think about it but it could be done better.
