### PR TITLE
Disables the script for the Happy Holidays Event page

### DIFF
--- a/Extended_Steamgifts.user.js
+++ b/Extended_Steamgifts.user.js
@@ -4,6 +4,7 @@
 // @author		Nandee
 // @namespace	esg
 // @include	    *steamgifts.com*
+// @exclude     *.steamgifts.com/happy-holidays*
 // @version		2.4.5
 // @downloadURL	https://github.com/nandee95/Extended_Steamgifts/raw/master/Extended_Steamgifts.user.js
 // @updateURL	https://github.com/nandee95/Extended_Steamgifts/raw/master/Extended_Steamgifts.user.js

--- a/Extended_Steamgifts_Enter_All.user.js
+++ b/Extended_Steamgifts_Enter_All.user.js
@@ -4,6 +4,7 @@
 // @author		Nandee
 // @namespace	esg
 // @include		*steamgifts.com*
+// @exclude     *.steamgifts.com/happy-holidays*
 // @version		1.0.1
 // @downloadURL	https://github.com/nandee95/Extended_Steamgifts/raw/master/Extended_Steamgifts_Enter_All.user.js
 // @updateURL	https://github.com/nandee95/Extended_Steamgifts/raw/master/Extended_Steamgifts_Enter_All.user.js


### PR DESCRIPTION
In the Happy Holidays Event page with the Gift Boxes, the script removes the page buttons and infinite scroll doesn't work. This simply disables the script for the event pages in order to avoid having to enable and disable it whenever browsing the event.

Also note that the event's giveaways follow SteamGifts regular URLs, so this won't affect them.